### PR TITLE
add json patch for streamer message json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,12 +451,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -604,7 +604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -815,6 +815,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -1053,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1133,7 +1139,7 @@ checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1155,7 +1161,7 @@ dependencies = [
 [[package]]
 name = "near-config-utils"
 version = "2.8.0"
-source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#5c0e571317bd6b58e211057ce767306794d20cd5"
+source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#13601d0c42c6a75acd54b17117ef75b73d638447"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -1166,7 +1172,7 @@ dependencies = [
 [[package]]
 name = "near-crypto"
 version = "2.8.0"
-source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#5c0e571317bd6b58e211057ce767306794d20cd5"
+source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#13601d0c42c6a75acd54b17117ef75b73d638447"
 dependencies = [
  "blake2",
  "borsh",
@@ -1190,7 +1196,7 @@ dependencies = [
 [[package]]
 name = "near-fmt"
 version = "2.8.0"
-source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#5c0e571317bd6b58e211057ce767306794d20cd5"
+source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#13601d0c42c6a75acd54b17117ef75b73d638447"
 dependencies = [
  "near-primitives-core",
 ]
@@ -1198,7 +1204,7 @@ dependencies = [
 [[package]]
 name = "near-indexer-primitives"
 version = "2.8.0"
-source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#5c0e571317bd6b58e211057ce767306794d20cd5"
+source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#13601d0c42c6a75acd54b17117ef75b73d638447"
 dependencies = [
  "near-primitives",
  "serde",
@@ -1207,7 +1213,7 @@ dependencies = [
 [[package]]
 name = "near-parameters"
 version = "2.8.0"
-source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#5c0e571317bd6b58e211057ce767306794d20cd5"
+source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#13601d0c42c6a75acd54b17117ef75b73d638447"
 dependencies = [
  "borsh",
  "enum-map",
@@ -1225,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "near-primitives"
 version = "2.8.0"
-source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#5c0e571317bd6b58e211057ce767306794d20cd5"
+source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#13601d0c42c6a75acd54b17117ef75b73d638447"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -1263,7 +1269,7 @@ dependencies = [
 [[package]]
 name = "near-primitives-core"
 version = "2.8.0"
-source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#5c0e571317bd6b58e211057ce767306794d20cd5"
+source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#13601d0c42c6a75acd54b17117ef75b73d638447"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -1283,12 +1289,12 @@ dependencies = [
 [[package]]
 name = "near-schema-checker-core"
 version = "2.8.0"
-source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#5c0e571317bd6b58e211057ce767306794d20cd5"
+source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#13601d0c42c6a75acd54b17117ef75b73d638447"
 
 [[package]]
 name = "near-schema-checker-lib"
 version = "2.8.0"
-source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#5c0e571317bd6b58e211057ce767306794d20cd5"
+source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#13601d0c42c6a75acd54b17117ef75b73d638447"
 dependencies = [
  "near-schema-checker-core",
  "near-schema-checker-macro",
@@ -1297,17 +1303,17 @@ dependencies = [
 [[package]]
 name = "near-schema-checker-macro"
 version = "2.8.0"
-source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#5c0e571317bd6b58e211057ce767306794d20cd5"
+source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#13601d0c42c6a75acd54b17117ef75b73d638447"
 
 [[package]]
 name = "near-stdx"
 version = "2.8.0"
-source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#5c0e571317bd6b58e211057ce767306794d20cd5"
+source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#13601d0c42c6a75acd54b17117ef75b73d638447"
 
 [[package]]
 name = "near-time"
 version = "2.8.0"
-source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#5c0e571317bd6b58e211057ce767306794d20cd5"
+source = "git+https://github.com/kobayurii/nearcore?branch=fork%2F2.8.0#13601d0c42c6a75acd54b17117ef75b73d638447"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1526,7 +1532,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -1707,7 +1713,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1938,7 +1944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1968,7 +1974,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -2025,7 +2031,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2094,7 +2100,7 @@ dependencies = [
  "slab",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2498,6 +2504,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/src/config.rs
+++ b/src/config.rs
@@ -104,10 +104,10 @@ impl BlocksApiConfig {
     pub async fn request(&self) -> blocksapi::ReceiveBlocksRequest {
         let mut start_policy =
             blocksapi::receive_blocks_request::StartPolicy::StartOnLatestAvailable;
-        let mut start_target = None;
+        let mut start_target_block = None;
         if self.start_on.is_some() {
             start_policy = blocksapi::receive_blocks_request::StartPolicy::StartOnClosestToTarget;
-            start_target = Some(blocksapi::block_message::Id {
+            start_target_block = Some(blocksapi::block_message::Id {
                 kind: blocksapi::block_message::Kind::MsgWhole as i32,
                 height: self.start_on.unwrap(),
                 shard_id: 0, // Default shard ID
@@ -119,7 +119,7 @@ impl BlocksApiConfig {
             stream_origin: String::new(), // Empty string for default origin
             start_policy: start_policy as i32,
             stop_policy: blocksapi::receive_blocks_request::StopPolicy::StopNever as i32,
-            start_target: start_target,
+            start_target: start_target_block,
             stop_target: None,
             delivery_settings: None,
             catchup_policy: blocksapi::receive_blocks_request::CatchupPolicy::CatchupStream as i32,

--- a/src/example.main.rs
+++ b/src/example.main.rs
@@ -56,7 +56,6 @@ async fn handle_streamer_message(
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-
     // Get configuration from environment variables
     let server_addr =
         env::var("BLOCKS_API_SERVER_ADDR").unwrap_or_else(|_| "http://localhost:4300".to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@ pub mod payloads {
 
 pub(crate) const BLOCKSAPI_RS: &str = "blocksapi-rs";
 
-// Borealis envelope structure
-// The struct uses `cbor:",toarray"` which means it's serialized as an array
+/// Borealis envelope structure
+/// The struct uses `cbor:",toarray"` which means it's serialized as an array
 #[derive(serde::Deserialize, Debug)]
 #[allow(dead_code)]
 struct BorealisEnvelope(
@@ -39,6 +39,10 @@ struct BorealisEnvelope(
     [u8; 16], // unique_id
 );
 
+/// Decode the Borealis payload which is prefixed with a 1-byte version
+/// Currently only version 1 is supported
+/// The payload is expected to be in the format:
+/// [1-byte version][BorealisEnvelope][actual payload bytes]
 async fn decode_borealis_payload<T>(data: &[u8]) -> anyhow::Result<T>
 where
     T: for<'de> serde::Deserialize<'de>,
@@ -66,6 +70,10 @@ where
     }
 }
 
+/// Decode the Borealis payload containing LZ4 compressed JSON data
+/// The payload is expected to be in the format:
+/// [1-byte version][BorealisEnvelope][LZ4 compressed JSON bytes]
+/// Returns the decompressed JSON bytes
 async fn decode_near_block_json(data: &[u8]) -> anyhow::Result<Vec<u8>> {
     // First decode the borealis payload to get the LZ4 compressed data
     let lz4_data: Vec<u8> = decode_borealis_payload(data).await?;
@@ -74,6 +82,27 @@ async fn decode_near_block_json(data: &[u8]) -> anyhow::Result<Vec<u8>> {
     Ok(buf)
 }
 
+/// Patch the JSON to add missing fields for compatibility with near-indexer-primitives
+/// Specificaly, add "chunks": [] if missing in the block object
+/// This is needed because near-indexer-primitives expects the "chunks" field to be present
+/// even if it's empty
+async fn patch_streamer_message_json(json_data: Vec<u8>) -> anyhow::Result<serde_json::Value> {
+    let mut json_msg = serde_json::from_slice::<serde_json::Value>(&json_data)?;
+    if let Some(block) = json_msg.get_mut("block") {
+        if let Some(block_obj) = block.as_object_mut() {
+            // Add chunks field as empty array if it doesn't exist
+            block_obj
+                .entry("chunks")
+                .or_insert_with(|| serde_json::Value::Array(vec![]));
+        }
+    }
+
+    Ok(json_msg)
+}
+
+/// Convert a `blocksapi::ReceiveBlocksResponse` to `near_indexer_primitives::StreamerMessage`
+/// by decoding the payload and deserializing the JSON
+/// This function handles only the PAYLOAD_NEAR_BLOCK_V2 format for now
 async fn convert_to_streamer_message(
     message: blocksapi::ReceiveBlocksResponse,
 ) -> anyhow::Result<near_indexer_primitives::StreamerMessage> {
@@ -102,9 +131,10 @@ async fn convert_to_streamer_message(
         blocksapi::block_message::Format::PayloadNearBlockV2 => {
             // For V2, we need to decode the borealis envelope and decompress LZ4
             let json_data = decode_near_block_json(&raw_payload).await?;
-            Ok(serde_json::from_slice::<
+            let streamer_msg_json = patch_streamer_message_json(json_data).await?;
+            Ok(serde_json::from_value::<
                 near_indexer_primitives::StreamerMessage,
-            >(&json_data)?)
+            >(streamer_msg_json)?)
         }
         _ => {
             anyhow::bail!("Unsupported block message format: {:?}", msg.format);


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the Rust gRPC client for streaming blockchain data. The main changes focus on enhancing payload decoding, improving compatibility with downstream consumers, and cleaning up code and documentation.

**Payload decoding and compatibility improvements:**

* Added a new function `patch_streamer_message_json` to ensure the "chunks" field is present in the block object of the decoded JSON, improving compatibility with `near-indexer-primitives`. This is now used in the conversion process from `blocksapi::ReceiveBlocksResponse` to `StreamerMessage`. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R85-R105) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L105-R137)
* Improved documentation and structure for the Borealis payload decoding functions, including clarifying comments and separating concerns for decoding and decompressing payloads. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L30-R31) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R42-R45) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R73-R76)

**Configuration and naming refactorings:**

* Renamed variables in `BlocksApiConfig::request` to clarify their purpose (`start_target` to `start_target_block`) and updated usage accordingly. [[1]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL107-R110) [[2]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL122-R122)

**Minor cleanup:**

* Removed an unnecessary blank line in `src/example.main.rs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added versioned Borealis payload decoding with validation and erroring on unknown/empty data.
  - Added LZ4 decompression for embedded JSON and conversion to streamer messages (supports NEAR block payload v2).
  - Automatically patches JSON to include an empty “chunks” array when missing.
- Bug Fixes
  - Prevents failures when the “chunks” field is absent by auto-inserting it.
- Documentation
  - Improved and expanded doc comments for decoding and conversion functions.
- Style
  - Minor whitespace cleanup.
- Chores
  - Internal variable rename for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->