### PR TITLE
reexport near_indexer_primitives

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 extern crate derive_builder;
 
+pub use near_indexer_primitives;
+
 use futures::StreamExt;
 use std::io::Read;
 use tokio::sync::mpsc;


### PR DESCRIPTION
This pull request introduces a minor update to the `src/lib.rs` file, making the `near_indexer_primitives` crate publicly available for downstream crates. No other changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Exposed indexer primitives through the main crate, enabling direct access from the crate root.
  - Simplifies imports for consumers and reduces the need to reference auxiliary crates.
  - No runtime behavior changes; purely an API surface enhancement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->