### PR TITLE
add the protoc-bin-vendored crate, which downloads a prebuilt protoc binary automatically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ dependencies = [
  "lz4",
  "near-indexer-primitives",
  "prost",
+ "protoc-bin-vendored",
  "serde",
  "serde_json",
  "tokio",
@@ -1569,6 +1570,70 @@ checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
 dependencies = [
  "prost",
 ]
+
+[[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "pulldown-cmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ near-indexer-primitives = { git = "https://github.com/kobayurii/nearcore", branc
 
 [build-dependencies]
 tonic-prost-build = "0.14.2"
+protoc-bin-vendored = "3"

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let protoc = protoc_bin_vendored::protoc_bin_path().unwrap();
+    std::env::set_var("PROTOC", protoc);
+    
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
     // Look for proto files in the submodule directory

--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let protoc = protoc_bin_vendored::protoc_bin_path().unwrap();
     std::env::set_var("PROTOC", protoc);
-    
+
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
     // Look for proto files in the submodule directory


### PR DESCRIPTION
This pull request updates the build process to ensure a vendored version of the Protocol Buffers compiler (`protoc`) is used, improving reliability and consistency across different environments.

Build system improvements:

* Added `protoc-bin-vendored` as a build dependency in `Cargo.toml` to provide a vendored `protoc` binary.
* Updated `build.rs` to set the `PROTOC` environment variable to the path of the vendored `protoc` binary, ensuring the build uses the correct compiler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added a vendored protoc build dependency and configured the build to use the bundled compiler for protobuf code generation.
  - Build process now ensures a vendored protoc binary is available for codegen; no runtime behavior or feature changes.
  - No changes to runtime dependencies, public APIs, or proto discovery/build outputs.
  - No direct user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->