### PR TITLE
refactors and modernizes the Rust gRPC client for streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "blocksapi-rs"
+name = "blocksapi"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "blocksapi-rs"
+name = "blocksapi"
 version = "0.1.0"
 edition = "2021"
 description = "A Rust gRPC client for streaming blockchain data"
 license = "MIT OR Apache-2.0"
 
 [lib]
-name = "blocksapi_rs"
+name = "blocksapi"
 path = "src/lib.rs"
 
 [dependencies]
@@ -28,7 +28,6 @@ tokio-stream = "0.1"
 tonic = "0.14.2"
 tonic-prost = "0.14.2"
 tracing = "0.1.40"
-
 
 near-indexer-primitives = { git = "https://github.com/kobayurii/nearcore", branch = "fork/2.8.0" }
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ let config = BlocksApiConfigBuilder::default()
 	.batch_size(50)
 	.build()?;
 
-let (task, mut rx) = blocksapi_rs::streamer(config);
+let (task, mut rx) = blocksapi::streamer(config);
 while let Some(msg) = rx.recv().await {
 	// Process StreamerMessage
 	do_something(&msg)?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,110 @@
+use crate::borealis_blocksapi;
+
+type BlocksProvider =
+    borealis_blocksapi::blocks_provider_client::BlocksProviderClient<tonic::transport::Channel>;
+
+pub struct BlocksApiClient {
+    provider: BlocksProvider,
+    metadata: tonic::metadata::MetadataMap,
+    stream_name: String,
+}
+
+impl BlocksApiClient {
+    async fn prepare_provider(
+        config: &crate::config::BlocksApiConfig,
+    ) -> anyhow::Result<BlocksProvider> {
+        let endpoint = tonic::transport::Endpoint::from_shared(config.server_addr.clone())?
+            .tcp_keepalive(Some(std::time::Duration::from_secs(config.tcp_keepalive)))
+            .http2_keep_alive_interval(std::time::Duration::from_secs(
+                config.http2_keepalive_interval,
+            ))
+            .keep_alive_timeout(std::time::Duration::from_secs(config.keepalive_timeout))
+            .connect_timeout(std::time::Duration::from_secs(config.connect_timeout))
+            .http2_adaptive_window(config.http2_adaptive_window)
+            .initial_connection_window_size(Some(config.connection_window_size))
+            .initial_stream_window_size(Some(config.stream_window_size))
+            .concurrency_limit(config.concurrency_limit)
+            .buffer_size(config.buffer_size);
+
+        let channel = endpoint.connect().await?;
+
+        Ok(borealis_blocksapi::blocks_provider_client::BlocksProviderClient::new(channel))
+    }
+
+    async fn prepare_metadata(
+        config: &crate::config::BlocksApiConfig,
+    ) -> tonic::metadata::MetadataMap {
+        let mut metadata = tonic::metadata::MetadataMap::new();
+        if let Some(token) = config.blocksapi_token.clone() {
+            if !token.is_empty() {
+                let auth_header = format!("Bearer {}", token);
+                if let Ok(auth_value) = tonic::metadata::MetadataValue::try_from(auth_header) {
+                    metadata.insert("authorization", auth_value);
+                }
+            }
+        }
+        metadata
+    }
+
+    pub async fn from_config(config: &crate::config::BlocksApiConfig) -> anyhow::Result<Self> {
+        let provider = Self::prepare_provider(config).await?;
+        let metadata = Self::prepare_metadata(config).await;
+        Ok(Self {
+            provider,
+            metadata,
+            stream_name: config.stream_name.clone(),
+        })
+    }
+
+    async fn streaming_request(
+        &self,
+        block_height: Option<u64>,
+    ) -> tonic::Request<borealis_blocksapi::ReceiveBlocksRequest> {
+        let (start_policy, start_target_block) = if let Some(block_height) = block_height {
+            (
+                borealis_blocksapi::receive_blocks_request::StartPolicy::StartOnClosestToTarget,
+                Some(borealis_blocksapi::block_message::Id {
+                    kind: borealis_blocksapi::block_message::Kind::MsgWhole as i32,
+                    height: block_height,
+                    shard_id: 0, // Default shard ID
+                }),
+            )
+        } else {
+            (
+                borealis_blocksapi::receive_blocks_request::StartPolicy::StartOnLatestAvailable,
+                None,
+            )
+        };
+
+        // Create the streaming request
+        let stream_request = borealis_blocksapi::ReceiveBlocksRequest {
+            stream_name: self.stream_name.clone(),
+            stream_origin: String::new(), // Empty string for default origin
+            start_policy: start_policy as i32,
+            stop_policy: borealis_blocksapi::receive_blocks_request::StopPolicy::StopNever as i32,
+            start_target: start_target_block,
+            stop_target: None,
+            delivery_settings: None,
+            catchup_policy: borealis_blocksapi::receive_blocks_request::CatchupPolicy::CatchupStream
+                as i32,
+            catchup_delivery_settings: None,
+            cached_zstd_dicts_sha3_hashes: Vec::new(), // No cached dictionaries
+        };
+
+        // Prepare the gRPC request with metadata
+        let mut request = tonic::Request::new(stream_request);
+        *request.metadata_mut() = self.metadata.clone();
+        request
+    }
+
+    /// Stream blocks starting from the specified block height.
+    /// If `block_height` is `None`, start from the latest available block.
+    pub async fn get_stream(
+        &self,
+        block_height: Option<u64>,
+    ) -> anyhow::Result<tonic::Streaming<borealis_blocksapi::ReceiveBlocksResponse>> {
+        let request = self.streaming_request(block_height).await;
+        let streaming = self.provider.clone().receive_blocks(request).await?;
+        Ok(streaming.into_inner())
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,7 +21,8 @@ pub struct BlocksApiConfig {
     /// The address of the Blocks API server.
     #[builder(setter(into))]
     pub server_addr: String,
-    /// The block height to start streaming from if `start_on_latest` is false.
+    /// The block height to start streaming from
+    /// If None, streaming will start from the latest block.
     #[builder(default)]
     pub start_on: Option<u64>,
     /// The name of the stream to connect to.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,8 @@
-use crate::blocksapi;
-
 /// Configuration struct for Blocks API client
 /// NB! Consider using [`BlocksApiConfigBuilder`]
 /// Building the `BlocksApiConfig` example:
 /// ```
-/// use blocksapi_rs::BlocksApiConfigBuilder;
+/// use blocksapi::BlocksApiConfigBuilder;
 ///
 /// async fn main() {
 ///    let config = BlocksApiConfigBuilder::default()
@@ -15,7 +13,7 @@ use crate::blocksapi;
 ///        .expect("Failed to build BlocksApiConfig");
 /// }
 /// ```
-#[derive(Default, Builder)]
+#[derive(Clone, Default, Builder)]
 #[builder(pattern = "owned")]
 pub struct BlocksApiConfig {
     /// Connection parameters
@@ -78,66 +76,7 @@ pub struct BlocksApiConfig {
 }
 
 impl BlocksApiConfig {
-    pub async fn client(
-        &self,
-    ) -> anyhow::Result<
-        blocksapi::blocks_provider_client::BlocksProviderClient<tonic::transport::Channel>,
-    > {
-        let endpoint = tonic::transport::Endpoint::from_shared(self.server_addr.clone())?
-            .tcp_keepalive(Some(std::time::Duration::from_secs(self.tcp_keepalive)))
-            .http2_keep_alive_interval(std::time::Duration::from_secs(
-                self.http2_keepalive_interval,
-            ))
-            .keep_alive_timeout(std::time::Duration::from_secs(self.keepalive_timeout))
-            .connect_timeout(std::time::Duration::from_secs(self.connect_timeout))
-            .http2_adaptive_window(self.http2_adaptive_window)
-            .initial_connection_window_size(Some(self.connection_window_size))
-            .initial_stream_window_size(Some(self.stream_window_size))
-            .concurrency_limit(self.concurrency_limit)
-            .buffer_size(self.buffer_size);
-
-        let channel = endpoint.connect().await?;
-
-        Ok(blocksapi::blocks_provider_client::BlocksProviderClient::new(channel))
-    }
-
-    pub async fn request(&self) -> blocksapi::ReceiveBlocksRequest {
-        let mut start_policy =
-            blocksapi::receive_blocks_request::StartPolicy::StartOnLatestAvailable;
-        let mut start_target_block = None;
-        if self.start_on.is_some() {
-            start_policy = blocksapi::receive_blocks_request::StartPolicy::StartOnClosestToTarget;
-            start_target_block = Some(blocksapi::block_message::Id {
-                kind: blocksapi::block_message::Kind::MsgWhole as i32,
-                height: self.start_on.unwrap(),
-                shard_id: 0, // Default shard ID
-            });
-        }
-
-        blocksapi::ReceiveBlocksRequest {
-            stream_name: self.stream_name.clone(),
-            stream_origin: String::new(), // Empty string for default origin
-            start_policy: start_policy as i32,
-            stop_policy: blocksapi::receive_blocks_request::StopPolicy::StopNever as i32,
-            start_target: start_target_block,
-            stop_target: None,
-            delivery_settings: None,
-            catchup_policy: blocksapi::receive_blocks_request::CatchupPolicy::CatchupStream as i32,
-            catchup_delivery_settings: None,
-            cached_zstd_dicts_sha3_hashes: Vec::new(), // No cached dictionaries
-        }
-    }
-
-    pub async fn metadata(&self) -> tonic::metadata::MetadataMap {
-        let mut metadata = tonic::metadata::MetadataMap::new();
-        if let Some(token) = self.blocksapi_token.clone() {
-            if !token.is_empty() {
-                let auth_header = format!("Bearer {}", token);
-                if let Ok(auth_value) = tonic::metadata::MetadataValue::try_from(auth_header) {
-                    metadata.insert("authorization", auth_value);
-                }
-            }
-        }
-        metadata
+    pub async fn client(&self) -> anyhow::Result<crate::client::BlocksApiClient> {
+        crate::client::BlocksApiClient::from_config(self).await
     }
 }

--- a/src/example.main.rs
+++ b/src/example.main.rs
@@ -62,7 +62,7 @@ async fn main() -> anyhow::Result<()> {
     let start_block = env::var("BLOCKS_API_START_BLOCK")
         .ok()
         .and_then(|val| val.parse::<u64>().ok());
-    let api_token = env::var("BLOCKSAPI_TOKEN=").ok();
+    let api_token = env::var("BLOCKSAPI_TOKEN").ok();
 
     let config = blocksapi::BlocksApiConfigBuilder::default()
         .server_addr(server_addr)

--- a/src/example.main.rs
+++ b/src/example.main.rs
@@ -64,13 +64,13 @@ async fn main() -> anyhow::Result<()> {
         .and_then(|val| val.parse::<u64>().ok());
     let api_token = env::var("BLOCKSAPI_TOKEN=").ok();
 
-    let config = blocksapi_rs::config::BlocksApiConfigBuilder::default()
+    let config = blocksapi::BlocksApiConfigBuilder::default()
         .server_addr(server_addr)
         .start_on(Some(start_block.unwrap_or(132545138)))
         .blocksapi_token(api_token)
         .build()?;
 
-    let (sender, stream) = blocksapi_rs::streamer(config);
+    let (sender, stream) = blocksapi::streamer(config);
     let speed_tracker = std::sync::Arc::new(std::sync::Mutex::new(SpeedTracker::new()));
 
     let mut handlers = tokio_stream::wrappers::ReceiverStream::new(stream)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ async fn task_update_final_block_regularly(
                         anyhow::bail!("Stream error: {}", status);
                     }
                     None => {
-                        tracing::warn!(target: BLOCKSAPI, "End of stream reached");
+                        tracing::error!(target: BLOCKSAPI, "End of stream reached");
                         anyhow::bail!("End of stream reached");
                     }
                 }
@@ -110,6 +110,9 @@ async fn start(
             final_block_height =
                 final_block_height_atomic.load(std::sync::atomic::Ordering::SeqCst);
             retries += 1;
+            if final_block_height == 0 {
+                tracing::warn!(target: BLOCKSAPI, "Final block height still 0, retrying... ({}/{})", retries, MAX_ATTEMPTS);
+            }
         }
 
         if final_block_height == 0 {
@@ -119,7 +122,7 @@ async fn start(
             );
         }
 
-        tracing::info!(target: BLOCKSAPI, "Final block height available: {}", final_block_height);
+        tracing::debug!(target: BLOCKSAPI, "Final block height available: {}", final_block_height);
     }
 
     // Adjust batch size based on catch-up status
@@ -188,7 +191,7 @@ async fn start(
                                 if block_height < current_height {
                                     tracing::warn!(
                                         target: BLOCKSAPI,
-                                        "Warning: Block height {} is less than current height {}",
+                                        "Block height {} is less than current height {}",
                                         block_height,
                                         current_height
                                     );
@@ -215,7 +218,7 @@ async fn start(
                         anyhow::bail!("Stream error: {}", status);
                     }
                     None => {
-                        tracing::warn!(target: BLOCKSAPI, "End of stream reached");
+                        tracing::error!(target: BLOCKSAPI, "End of stream reached");
                         anyhow::bail!("End of stream reached");
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,9 +202,9 @@ async fn start(
                             }
                             // Update catchup status
                             let final_height = final_block_height_atomic.load(std::sync::atomic::Ordering::SeqCst);
-                            let checke_is_catchup = final_height > current_height + config.batch_size as u64;
-                            if is_catchup != checke_is_catchup {
-                                is_catchup = checke_is_catchup;
+                            let checked_is_catchup = final_height > current_height + config.batch_size as u64;
+                            if is_catchup != checked_is_catchup {
+                                is_catchup = checked_is_catchup;
                                 batch_size = if is_catchup { config.batch_size } else { 1 };
                                 tracing::info!(target: BLOCKSAPI, "Catchup status changed to: {}, new batch size: {}", is_catchup, batch_size);
                             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,120 @@
+use std::io::Read;
+
+/// Borealis envelope structure
+/// The struct uses `cbor:",toarray"` which means it's serialized as an array
+#[derive(serde::Deserialize, Debug)]
+#[allow(dead_code)]
+pub struct BorealisEnvelope(
+    u16,      // type_field
+    u64,      // sequential_id
+    u32,      // timestamp_s
+    u16,      // timestamp_ms
+    [u8; 16], // unique_id
+);
+
+/// Decode the Borealis payload which is prefixed with a 1-byte version
+/// Currently only version 1 is supported
+/// The payload is expected to be in the format:
+/// [1-byte version][BorealisEnvelope][actual payload bytes]
+pub async fn decode_borealis_payload<T>(data: &[u8]) -> anyhow::Result<T>
+where
+    T: for<'de> serde::Deserialize<'de>,
+{
+    if data.is_empty() {
+        return Err(anyhow::anyhow!("Empty data"));
+    }
+
+    let version = data[0];
+    match version {
+        1 => {
+            let mut reader = std::io::Cursor::new(&data[1..]);
+
+            // Decode the envelope first
+            let _envelope: BorealisEnvelope = ciborium::from_reader(&mut reader)?;
+
+            // Then decode the payload
+            let payload: T = ciborium::from_reader(&mut reader)?;
+            Ok(payload)
+        }
+        _ => Err(anyhow::anyhow!(
+            "Unknown version of borealis-message: {}",
+            version
+        )),
+    }
+}
+
+/// Decode the Borealis payload containing LZ4 compressed JSON data
+/// The payload is expected to be in the format:
+/// [1-byte version][BorealisEnvelope][LZ4 compressed JSON bytes]
+/// Returns the decompressed JSON bytes
+pub async fn decode_near_block_json(data: &[u8]) -> anyhow::Result<Vec<u8>> {
+    // First decode the borealis payload to get the LZ4 compressed data
+    let lz4_data: Vec<u8> = decode_borealis_payload(data).await?;
+    let mut buf = vec![];
+    lz4::Decoder::new(std::io::Cursor::new(lz4_data))?.read_to_end(&mut buf)?;
+    Ok(buf)
+}
+
+/// Patch the JSON to add missing fields for compatibility with near-indexer-primitives
+/// Specificaly, add "chunks": [] if missing in the block object
+/// This is needed because near-indexer-primitives expects the "chunks" field to be present
+/// even if it's empty
+pub async fn patch_streamer_message_json(json_data: Vec<u8>) -> anyhow::Result<serde_json::Value> {
+    let mut json_msg = serde_json::from_slice::<serde_json::Value>(&json_data)?;
+    if let Some(block) = json_msg.get_mut("block") {
+        if let Some(block_obj) = block.as_object_mut() {
+            // Add chunks field as empty array if it doesn't exist
+            block_obj
+                .entry("chunks")
+                .or_insert_with(|| serde_json::Value::Array(vec![]));
+        }
+    }
+
+    Ok(json_msg)
+}
+
+/// Convert a `blocksapi::ReceiveBlocksResponse` to `near_indexer_primitives::StreamerMessage`
+/// by decoding the payload and deserializing the JSON
+/// This function handles only the PAYLOAD_NEAR_BLOCK_V2 format for now
+pub async fn convert_to_streamer_message(
+    message: crate::borealis_blocksapi::ReceiveBlocksResponse,
+) -> anyhow::Result<near_indexer_primitives::StreamerMessage> {
+    let msg = match message.response {
+        Some(crate::borealis_blocksapi::receive_blocks_response::Response::Message(msg)) => {
+            match msg.message {
+                Some(block_msg) => block_msg,
+                None => {
+                    anyhow::bail!("Received BlockMessage with no message field");
+                }
+            }
+        }
+        _ => {
+            anyhow::bail!("Received message with no response field");
+        }
+    };
+
+    // Extract the raw payload
+    let raw_payload =
+        if let Some(crate::borealis_blocksapi::block_message::Payload::RawPayload(data)) =
+            msg.payload
+        {
+            data
+        } else {
+            anyhow::bail!("Unsupported payload type or missing payload");
+        };
+
+    // Check the format - we expect PAYLOAD_NEAR_BLOCK_V4 (JSON format)
+    match crate::borealis_blocksapi::block_message::Format::try_from(msg.format)? {
+        crate::borealis_blocksapi::block_message::Format::PayloadNearBlockV2 => {
+            // For V2, we need to decode the borealis envelope and decompress LZ4
+            let json_data = decode_near_block_json(&raw_payload).await?;
+            let streamer_msg_json = patch_streamer_message_json(json_data).await?;
+            Ok(serde_json::from_value::<
+                near_indexer_primitives::StreamerMessage,
+            >(streamer_msg_json)?)
+        }
+        _ => {
+            anyhow::bail!("Unsupported block message format: {:?}", msg.format);
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -103,7 +103,7 @@ pub async fn convert_to_streamer_message(
             anyhow::bail!("Unsupported payload type or missing payload");
         };
 
-    // Check the format - we expect PAYLOAD_NEAR_BLOCK_V4 (JSON format)
+    // Check the format - we expect PAYLOAD_NEAR_BLOCK_V2 (JSON format)
     match crate::borealis_blocksapi::block_message::Format::try_from(msg.format)? {
         crate::borealis_blocksapi::block_message::Format::PayloadNearBlockV2 => {
             // For V2, we need to decode the borealis envelope and decompress LZ4

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,6 @@
 use std::io::Read;
 
-/// Borealis envelope structure
-/// The struct uses `cbor:",toarray"` which means it's serialized as an array
+/// Borealis envelope structure (tuple struct, serialized as CBOR array)
 #[derive(serde::Deserialize, Debug)]
 #[allow(dead_code)]
 pub struct BorealisEnvelope(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -56,7 +56,7 @@ pub async fn decode_near_block_json(data: &[u8]) -> anyhow::Result<Vec<u8>> {
 }
 
 /// Patch the JSON to add missing fields for compatibility with near-indexer-primitives
-/// Specificaly, add "chunks": [] if missing in the block object
+/// Specifically, add "chunks": [] if missing in the block object
 /// This is needed because near-indexer-primitives expects the "chunks" field to be present
 /// even if it's empty
 pub async fn patch_streamer_message_json(json_data: Vec<u8>) -> anyhow::Result<serde_json::Value> {


### PR DESCRIPTION
This pull request refactors and modernizes the Rust gRPC client for streaming blockchain data, focusing on improved modularity, naming consistency, and streaming logic. The most significant changes include renaming the crate and library, introducing a dedicated `BlocksApiClient` for client functionality, moving payload and conversion utilities to a new `utils` module, and enhancing the block streaming startup logic for reliability and maintainability.

**Naming and Structure Updates**
* Renamed the crate and library from `blocksapi-rs`/`blocksapi_rs` to `blocksapi` for consistency throughout the codebase, including all code identifiers and constants. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L2-R9) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L30-L142) [[3]](diffhunk://#diff-000d5bba49bd44c58fddc7dc7685e5c971bd358b46676336518a96c001309debL67-R73)

**Client Abstraction and API**
* Introduced the new `BlocksApiClient` struct in `src/client.rs` to encapsulate gRPC client logic, including connection setup, metadata handling, and streaming requests. The `BlocksApiConfig` now returns a `BlocksApiClient` via its `client()` method, simplifying usage and improving code clarity. [[1]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1R1-R110) [[2]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL81-R80)

**Configuration Improvements**
* Made `BlocksApiConfig` `Clone` to support concurrent usage, and updated documentation and usage examples to reflect the new naming and API. [[1]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL1-R5) [[2]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL18-R16)

**Streaming Logic Enhancements**
* Refactored the block streaming startup in `src/lib.rs` to asynchronously determine the final block height before starting the main block stream, improving reliability and startup synchronization. The streaming logic now uses the new client abstraction and adapts batch size and catchup logic based on the latest block height.

**Utility and Conversion Refactoring**
* Moved payload decoding and conversion logic (including `convert_to_streamer_message`) into a new `utils` module, cleaning up the main library file and improving maintainability. Updated error handling and logging to use the new naming. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L7-R18) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L178-R143) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L196-R157) [[4]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L214-R172)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - gRPC client for streaming blocks.
  - Utilities to decode Borealis payloads, decompress/patch JSON, and emit streamer messages.
  - Background final-block tracking with catch-up handling and adaptive batching.

- **Breaking Changes**
  - Crate and public module paths renamed to "blocksapi".
  - Config API simplified: client() now returns a client; previous request()/metadata() accessors removed.

- **Documentation**
  - README and examples updated to new crate paths.

- **Chores**
  - Removed a git-based external dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->