### PR TITLE
maximum message size for gRPC messages

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -28,7 +28,12 @@ impl BlocksApiClient {
 
         let channel = endpoint.connect().await?;
 
-        Ok(borealis_blocksapi::blocks_provider_client::BlocksProviderClient::new(channel))
+        let client = borealis_blocksapi::blocks_provider_client::BlocksProviderClient::new(channel)
+            // Set maximum message sizes to handle large blockchain messages
+            .max_decoding_message_size(config.max_message_size)
+            .max_encoding_message_size(config.max_message_size);
+
+        Ok(client)
     }
 
     async fn prepare_metadata(

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,6 +74,10 @@ pub struct BlocksApiConfig {
     /// Default is 1024.
     #[builder(default = 1024)]
     pub concurrency_limit: usize,
+    /// The maximum message size for gRPC messages.
+    /// Default is 16MB to handle large blockchain messages.
+    #[builder(default = 16 * 1024 * 1024)]
+    pub max_message_size: usize,
 }
 
 impl BlocksApiConfig {


### PR DESCRIPTION
This pull request enhances the `BlocksApiClient` to better support large blockchain messages by introducing a configurable maximum gRPC message size. The configuration is now exposed in `BlocksApiConfig`, and the client is updated to use this setting when connecting.

Configuration improvements:

* Added a new `max_message_size` field to `BlocksApiConfig` with a default value of 16MB to allow handling of large gRPC messages.

Client initialization updates:

* Updated the `BlocksApiClient` connection logic to set both maximum decoding and encoding message sizes based on the new configuration, ensuring the client can send and receive large blockchain messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable maximum message size for API requests and responses, enabling support for larger payloads by default (16 MB) and allowing customization as needed.
  * Client now respects the configured limits for both sending and receiving, improving reliability when handling large data.

* **Improvements**
  * Increased default tolerance for large messages without additional setup, reducing the likelihood of failures with bigger responses or requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->